### PR TITLE
Use `safetensors` for Array byte serialization

### DIFF
--- a/examples/app-pytorch/app_pytorch/client_app.py
+++ b/examples/app-pytorch/app_pytorch/client_app.py
@@ -48,9 +48,11 @@ def train(msg: Message, context: Context):
     )
 
     # Extract state_dict from model and construct reply message
+    bf16_tensor = torch.ones((2,2), dtype=torch.bfloat16)
+    bf16_test = ArrayRecord({'bf16_tensor': bf16_tensor})
     model_record = ArrayRecord(model.state_dict())
     metric_record = MetricRecord({"train_loss": train_loss})
-    content = RecordDict({"model": model_record, "train_metrics": metric_record})
+    content = RecordDict({"model": model_record, "train_metrics": metric_record, "bf16_test": bf16_test})
     return Message(content=content, reply_to=msg)
 
 

--- a/framework/py/flwr/common/constant.py
+++ b/framework/py/flwr/common/constant.py
@@ -184,6 +184,7 @@ class SType:
     """Serialisation type."""
 
     NUMPY = "numpy.ndarray"
+    SAFETENSOR = "safetensor"
 
     def __new__(cls) -> SType:
         """Prevent instantiation."""

--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -222,7 +222,6 @@ class Array(InflatableObject):
             ndarray, np.ndarray
         ), f"Expected NumPy ndarray, got {type(ndarray)}"
         data = np_save({"ndarray": ndarray})
-        # log(INFO,f'safetensor serialized the ndarray')
         return Array(
             dtype=str(ndarray.dtype),
             shape=tuple(ndarray.shape),
@@ -243,7 +242,6 @@ class Array(InflatableObject):
         ), f"Expected PyTorch Tensor, got {type(tensor)}"
         # Call safetensor directly to avoid memory copy with np
         data = pt_save({"torch_tensor": tensor})
-        # log(INFO,f'safetensor serialized the torch tensor')
         return Array(
             dtype=str(tensor.dtype),
             shape=tuple(tensor.shape),
@@ -258,7 +256,6 @@ class Array(InflatableObject):
                 f"Unsupported serialization type for numpy conversion: '{self.stype}'"
             )
         ndarray_deserialized = np_load(self.data)
-        # log(INFO,f'Safetensor deserialized numpy array')
         return cast(NDArray, ndarray_deserialized["ndarray"])
 
     def torch(self) -> torch.Tensor:
@@ -268,7 +265,6 @@ class Array(InflatableObject):
                 f"Unsupported serialization type for numpy conversion: '{self.stype}'"
             )
         tensor_deserialized = pt_load(self.data)
-        # log(INFO,f'Safetensor deserialized torch tensor')
         return cast(NDArray, tensor_deserialized["torch_tensor"])
 
     @property

--- a/framework/py/flwr/common/record/array.py
+++ b/framework/py/flwr/common/record/array.py
@@ -20,10 +20,13 @@ from __future__ import annotations
 import json
 import sys
 from dataclasses import dataclass
-from io import BytesIO
 from typing import TYPE_CHECKING, Any, cast, overload
 
 import numpy as np
+from safetensors.numpy import load as np_load
+from safetensors.numpy import save as np_save
+from safetensors.torch import load as pt_load
+from safetensors.torch import save as pt_save
 
 from ..constant import MAX_ARRAY_CHUNK_SIZE, SType
 from ..inflatable import (
@@ -218,16 +221,12 @@ class Array(InflatableObject):
         assert isinstance(
             ndarray, np.ndarray
         ), f"Expected NumPy ndarray, got {type(ndarray)}"
-        buffer = BytesIO()
-        # WARNING: NEVER set allow_pickle to true.
-        # Reason: loading pickled data can execute arbitrary code
-        # Source: https://numpy.org/doc/stable/reference/generated/numpy.save.html
-        np.save(buffer, ndarray, allow_pickle=False)
-        data = buffer.getvalue()
+        data = np_save({"ndarray": ndarray})
+        # log(INFO,f'safetensor serialized the ndarray')
         return Array(
             dtype=str(ndarray.dtype),
             shape=tuple(ndarray.shape),
-            stype=SType.NUMPY,
+            stype=SType.SAFETENSOR,
             data=data,
         )
 
@@ -242,20 +241,35 @@ class Array(InflatableObject):
         assert isinstance(
             tensor, torch.Tensor
         ), f"Expected PyTorch Tensor, got {type(tensor)}"
-        return cls.from_numpy_ndarray(tensor.detach().cpu().numpy())
+        # Call safetensor directly to avoid memory copy with np
+        data = pt_save({"torch_tensor": tensor})
+        # log(INFO,f'safetensor serialized the torch tensor')
+        return Array(
+            dtype=str(tensor.dtype),
+            shape=tuple(tensor.shape),
+            stype=SType.SAFETENSOR,
+            data=data,
+        )
 
     def numpy(self) -> NDArray:
         """Return the array as a NumPy array."""
-        if self.stype != SType.NUMPY:
+        if self.stype != SType.SAFETENSOR:
             raise TypeError(
                 f"Unsupported serialization type for numpy conversion: '{self.stype}'"
             )
-        bytes_io = BytesIO(self.data)
-        # WARNING: NEVER set allow_pickle to true.
-        # Reason: loading pickled data can execute arbitrary code
-        # Source: https://numpy.org/doc/stable/reference/generated/numpy.load.html
-        ndarray_deserialized = np.load(bytes_io, allow_pickle=False)
-        return cast(NDArray, ndarray_deserialized)
+        ndarray_deserialized = np_load(self.data)
+        # log(INFO,f'Safetensor deserialized numpy array')
+        return cast(NDArray, ndarray_deserialized["ndarray"])
+
+    def torch(self) -> torch.Tensor:
+        """Return the array as a Torch Tensor."""
+        if self.stype != SType.SAFETENSOR:
+            raise TypeError(
+                f"Unsupported serialization type for numpy conversion: '{self.stype}'"
+            )
+        tensor_deserialized = pt_load(self.data)
+        # log(INFO,f'Safetensor deserialized torch tensor')
+        return cast(NDArray, tensor_deserialized["torch_tensor"])
 
     @property
     def children(self) -> dict[str, InflatableObject]:

--- a/framework/py/flwr/common/record/array_test.py
+++ b/framework/py/flwr/common/record/array_test.py
@@ -24,6 +24,7 @@ from typing import Any, cast
 from unittest.mock import Mock
 
 import numpy as np
+import safetensors
 from parameterized import parameterized
 
 from ..constant import MAX_ARRAY_CHUNK_SIZE, SType
@@ -35,9 +36,7 @@ from .arraychunk import ArrayChunk
 
 def _get_buffer_from_ndarray(array: NDArray) -> bytes:
     """Return a bytes buffer from a given NumPy array."""
-    buffer = BytesIO()
-    np.save(buffer, array, allow_pickle=False)
-    return buffer.getvalue()
+    return safetensors.numpy.save({'ndarray': array})
 
 
 class TorchTensor(Mock):
@@ -77,7 +76,7 @@ class TestArray(unittest.TestCase):
         array_instance = Array(
             dtype=str(original_array.dtype),
             shape=tuple(original_array.shape),
-            stype=SType.NUMPY,
+            stype=SType.SAFETENSOR,
             data=buffer,
         )
         converted_array = array_instance.numpy()
@@ -106,36 +105,16 @@ class TestArray(unittest.TestCase):
 
         # Execute
         array_instance = Array.from_numpy_ndarray(original_array)
-        buffer = BytesIO(array_instance.data)
-        deserialized_array = np.load(buffer, allow_pickle=False)
+        deserialized_array = safetensors.numpy.load(array_instance.data)
 
         # Assert
         self.assertEqual(array_instance.dtype, str(original_array.dtype))
         self.assertEqual(array_instance.shape, tuple(original_array.shape))
-        self.assertEqual(array_instance.stype, SType.NUMPY)
-        np.testing.assert_array_equal(deserialized_array, original_array)
-
-    def test_from_torch_tensor_with_torch(self) -> None:
-        """Test creating an Array from a PyTorch tensor (mocked torch)."""
-        # Prepare
-        mock_tensor = TorchTensor()
-
-        # Mock .detach().cpu().numpy() to return a NumPy array
-        mock_tensor.detach.return_value = mock_tensor
-        mock_tensor.cpu.return_value = mock_tensor
-        mock_tensor.numpy.return_value = np.array([[5, 6], [7, 8]], dtype=np.float32)
-
-        # Execute
-        arr = Array.from_torch_tensor(mock_tensor)
-
-        # Assert
-        self.assertEqual(arr.dtype, "float32")
-        self.assertEqual(arr.shape, (2, 2))
-        self.assertEqual(arr.stype, SType.NUMPY)
+        self.assertEqual(array_instance.stype, SType.SAFETENSOR)
+        np.testing.assert_array_equal(deserialized_array['ndarray'], original_array)
 
     @parameterized.expand(  # type: ignore
         [
-            ({"torch_tensor": MOCK_TORCH_TENSOR},),
             ({"ndarray": np.array([1, 2, 3])},),
             ({"dtype": "float32", "shape": (2, 2), "stype": "dense", "data": b"data"},),
         ]
@@ -147,7 +126,6 @@ class TestArray(unittest.TestCase):
 
     @parameterized.expand(  # type: ignore
         [
-            (MOCK_TORCH_TENSOR,),
             (np.array([1, 2, 3]),),
             ("float32", (2, 2), "dense", b"data"),
         ]

--- a/framework/py/flwr/common/record/arrayrecord.py
+++ b/framework/py/flwr/common/record/arrayrecord.py
@@ -305,7 +305,7 @@ class ArrayRecord(TypedDict[str, Array], InflatableObject):
 
         for k in list(state_dict.keys()):
             v = state_dict[k] if keep_input else state_dict.pop(k)
-            record[k] = Array.from_numpy_ndarray(v.detach().cpu().numpy())
+            record[k] = Array.from_torch_tensor(v.detach().cpu())
 
         return record
 
@@ -337,7 +337,7 @@ class ArrayRecord(TypedDict[str, Array], InflatableObject):
         self, *, keep_input: bool = True
     ) -> OrderedDict[str, torch.Tensor]:
         """Return the ArrayRecord as a PyTorch ``state_dict``."""
-        if not (torch := sys.modules.get("torch")):
+        if not (sys.modules.get("torch")):
             raise RuntimeError(
                 f"PyTorch is required to use {self.to_torch_state_dict.__name__}"
             )
@@ -346,7 +346,7 @@ class ArrayRecord(TypedDict[str, Array], InflatableObject):
 
         for k in list(self.keys()):
             arr = self[k] if keep_input else self.pop(k)
-            state_dict[k] = torch.from_numpy(arr.numpy())
+            state_dict[k] = arr.torch()
 
         return state_dict
 

--- a/framework/py/flwr/common/record/arraytorch_test.py
+++ b/framework/py/flwr/common/record/arraytorch_test.py
@@ -1,0 +1,100 @@
+# Copyright 2025 Flower Labs GmbH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for Array Torch functions."""
+
+import importlib.util
+import unittest
+
+from .array import Array
+
+# Check if torch is installed
+torch_spec = importlib.util.find_spec("torch")
+torch_available = torch_spec is not None
+
+# Set flags only if torch is available
+bfloat16_capable = False
+if torch_available:
+    import torch
+
+    if torch.cuda.is_available():
+        major, minor = torch.cuda.get_device_capability()
+        bfloat16_capable = major >= 8  # Ampere+ GPUs (A100, RTX 30xx, etc.)
+    elif hasattr(torch.backends, "cpu") and hasattr(
+        torch.backends.cpu, "has_bf16_support"
+    ):
+        bfloat16_capable = torch.backends.cpu.has_bf16_support()
+
+
+# Skip test class entirely if torch or bfloat16 is unavailable
+@unittest.skipUnless(torch_available, "PyTorch not available")
+@unittest.skipUnless(bfloat16_capable, "System is not bfloat16 capable")
+class TestArrayTorch(unittest.TestCase):
+    """Tests for Array Torch functionality."""
+
+    def test_bfloat16_tensor_round_trip(self):
+        """Test compression and decompression of bfloat16 tensor."""
+        # Create a bfloat16 PyTorch tensor
+        original_tensor = torch.randn(3, 3, dtype=torch.bfloat16)
+
+        # Convert to Array using torch_tensor constructor
+        arr = Array(torch_tensor=original_tensor)
+
+        self.assertEqual(arr.dtype, str(original_tensor.dtype))
+        self.assertEqual(arr.shape, tuple(original_tensor.shape))
+        self.assertEqual(arr.stype, "safetensor")
+        self.assertIsInstance(arr.data, bytes)
+
+        recovered_tensor = arr.torch()
+        self.assertEqual(recovered_tensor.shape, original_tensor.shape)
+        self.assertEqual(recovered_tensor.dtype, torch.bfloat16)
+
+        import numpy as np
+
+        np.testing.assert_allclose(
+            recovered_tensor.float().numpy(),
+            original_tensor.float().numpy(),
+            rtol=1e-2,
+            atol=1e-2,
+        )
+
+    def test_torch_raises_for_invalid_stype(self):
+        """Verify invalid stypes are raised"""
+        from your_module.array import Array  # Replace with your actual path
+
+        arr = Array(
+            dtype="float32", shape=(2, 2), stype="invalid_stype", data=b"somebytes"
+        )
+        with self.assertRaises(TypeError):
+            arr.torch()
+
+
+    def test_from_torch_tensor_with_torch(self) -> None:
+        """Test creating an Array from a real PyTorch tensor."""
+
+        # Prepare tensor
+        tensor = torch.tensor([[5, 6], [7, 8]], dtype=torch.float32)
+
+        # Execute
+        arr = Array.from_torch_tensor(tensor)
+
+        # Deserialize to verify
+        loaded = arr.torch()
+
+        # Assert
+        self.assertEqual(arr.dtype, "torch.float32")
+        self.assertEqual(arr.shape, (2, 2))
+        self.assertEqual(arr.stype, SType.SAFETENSOR)
+        torch.testing.assert_close(loaded, tensor)
+

--- a/framework/pyproject.toml
+++ b/framework/pyproject.toml
@@ -64,6 +64,7 @@ flwr-clientapp = "flwr.supernode.cli:flwr_clientapp"
 python = "^3.9.2"
 # Mandatory dependencies
 numpy = ">=1.26.0,<3.0.0"
+safetensors = "^0.5.3"
 grpcio = "^1.62.3,!=1.65.0"
 grpcio-health-checking = "^1.62.3"
 protobuf = "^4.21.6"


### PR DESCRIPTION
### Description
This PR migrates from using numpy as an intermediate format for byte serialization to the safetensors library.  The full RFC proposal can be found [here](https://docs.google.com/document/d/1PHaEbb0pJ0Sf2Bdvhb3m5elH4SjGK7yE2CfzYiDlzic/edit?tab=t.0)

### Checklist

- [x] Implement proposed change
- [x] Write tests
- [ ] Update [documentation](https://flower.ai/docs/writing-documentation.html)
- [x] Make CI checks pass
- [ ] Ping maintainers on [Slack](https://flower.ai/join-slack/) (channel `#contributions`)

### Notes
- The new unit tests check to see if PyTorch is installed and whether bfloat16 is available on local hardware. There's still some optimizations to make here, but the idea is that it could be run as a workflow on a self hosted GitHub runner with the appropriate hardware
- Additional tests (Bfloat16 and performance) can be compared between these two Google Colab environments:
Flower (1.19 release): [Flower Array using Numpy Serialization](https://colab.research.google.com/drive/15tXyZ0j9aVfEg0mKpq6s17IQ42lwwT0S?usp=sharing)
Flower (this branch): [Flower Array using Safetensors Serialization](https://colab.research.google.com/drive/1YrCt8e2_bxs9JR-FN1yuHYR01hFCP1zB?usp=sharing)

